### PR TITLE
Change colors with new brand aesthetics

### DIFF
--- a/_quarto.yml
+++ b/_quarto.yml
@@ -20,6 +20,9 @@ resources:
   - CNAME
 format:
   html:
+    respect-user-color-scheme: true
     theme:
-      light: [flatly, assets/css/theme-light.scss]
-      dark: [darkly, assets/css/theme-dark.scss]
+      light: [cosmo, assets/css/theme-light.scss]
+      dark: [cosmo, assets/css/theme-dark.scss]
+
+toc: true

--- a/assets/css/theme-dark.scss
+++ b/assets/css/theme-dark.scss
@@ -1,10 +1,23 @@
 /*-- scss:defaults --*/
+// Base document colors
+$body-bg: #181818;
+$body-color: #ccc;
+$link-color: #75AADB;
 
-$body-bg: #181c1f;
-$link-color: #db4a32;
+// Code blocks
+$code-block-bg-alpha: -.9;
 
 /* css styles */
 
-.navbar {
-    background-color: transparent !important;
-  }
+.navbar a {
+    color: white;
+}
+
+.navbar a:hover {
+    color: $link-color;
+}
+
+code {
+  background-color: transparent !important;
+  color: $link-color !important;
+}

--- a/assets/css/theme-light.scss
+++ b/assets/css/theme-light.scss
@@ -1,9 +1,20 @@
 /*-- scss:defaults --*/
 
-$link-color: #db4a32;
+$link-color: #3b82f6;
+$light-blue: #e3eefb;
+$font-black: #2c323f;
 
 /* css styles */
 
 .navbar {
     background-color: transparent !important;
-  }
+    color: $link-color;
+}
+
+.navbar a {
+    color: $font-black;
+}
+
+.navbar a:hover {
+    color: $link-color;
+}


### PR DESCRIPTION
There were some minor problems with the CSS colours (especially navbar). 

I've adapted them to the new graphic charter, with blue dominating.

As I didn't have the blue logo, I left the good old orange logo in the navbar.

Incidentally, I've upgraded the white/dark management system with the latest Quarto features.